### PR TITLE
docs(ci-cd): add canonical workflow guide and align docs

### DIFF
--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -8,6 +8,28 @@ LumenFlow follows semantic versioning and a 3-tier release process:
 - **Stable Release:** Production-ready versions
 - **Long-Term Support (LTS):** Maintenance versions for critical patches
 
+## CI/CD Release Process
+
+LumenFlow release binaries are built by GitHub Actions workflow `release.yml`.
+
+Current release policy:
+
+- Triggered by version tag push matching `v*` (for example `v0.2.1`)
+- Builds artifacts for Linux, Windows, macOS Intel, and macOS Apple Silicon
+- Uploads artifacts to GitHub Release assets
+- Unsigned artifacts by default (signing/notarization can be enabled later with secrets)
+
+Recommended release sequence:
+
+1. Merge `develop` into `main` with green checks.
+2. Bump versions in `package.json`, workspace `Cargo.toml`, and `tauri.conf.json`.
+3. Create and push tag on `main`.
+4. Verify workflow output and attached release assets.
+
+For full contributor/operator flow (including `ci:heavy` usage), see:
+
+- [`docs/development/CI_CD_WORKFLOW.md`](../development/CI_CD_WORKFLOW.md)
+
 ## Building for Distribution
 
 ### Desktop Application (Tauri)

--- a/docs/development/CI_CD_WORKFLOW.md
+++ b/docs/development/CI_CD_WORKFLOW.md
@@ -1,0 +1,189 @@
+# CI/CD Workflow (Humans and Agents)
+
+This document is the source of truth for LumenFlow CI/CD operations.
+
+It explains:
+
+- what runs on every PR/push
+- how to run heavy checks
+- how to ship a release
+- what to fix in code vs what to fix in pipeline setup
+
+## 1. Current GitHub Actions Workflows
+
+### `ci.yml` (light PR CI, required)
+
+Purpose: fast, deterministic quality gate for daily work.
+
+Triggers:
+
+- `pull_request` to `main` or `develop`
+- `push` to `main` or `develop`
+
+Main jobs:
+
+- Rust quality: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo audit`
+- Rust tests: `cargo test --workspace --all-features`
+- TypeScript quality: format check, type-check, lint
+- TypeScript tests: unit tests + coverage command
+- Build smoke: Linux build validation (no release drafting)
+
+This workflow must stay stable and non-flaky.
+
+### `ci-heavy.yml` (optional heavy checks)
+
+Purpose: expensive and/or privilege-sensitive checks not required for every PR.
+
+Triggers:
+
+- `pull_request` when label `ci:heavy` is present
+- nightly schedule
+- manual run (`workflow_dispatch`)
+
+Jobs:
+
+- Playwright visual regression
+- Wireshark compliance
+- Benchmarks
+
+### `release.yml` (CD release builds)
+
+Purpose: produce distributable binaries and attach them to GitHub Releases.
+
+Triggers:
+
+- tag push matching `v*` (for example: `v0.2.1`)
+- manual run (`workflow_dispatch`)
+
+Target matrix:
+
+- Linux x64
+- Windows x64
+- macOS Intel (`x86_64-apple-darwin`)
+- macOS Apple Silicon (`aarch64-apple-darwin`)
+
+Current policy:
+
+- unsigned release artifacts by default (open-source early stage)
+- signing/notarization can be added later via secrets
+
+## 2. Daily Development Flow
+
+1. Create feature branch from `develop`.
+2. Commit and push normally (no special commit message needed).
+3. Open PR to `develop`.
+4. Wait for `ci.yml` checks to pass.
+5. If needed, add PR label `ci:heavy` to run heavy checks.
+6. Merge when green.
+
+Notes:
+
+- `ci:heavy` is a PR label, not a commit message.
+- GitHub uses "Pull Request" terminology. It is functionally similar to "Merge Request."
+
+## 3. Release Flow
+
+1. Merge `develop` into `main` via PR.
+2. Ensure PR checks are green.
+3. Bump versions in:
+   - `package.json`
+   - `Cargo.toml` workspace version
+   - `crates/lumenflow_ui/src-tauri/tauri.conf.json`
+4. Create and push tag on `main`, for example:
+   - `v0.2.1`
+5. `release.yml` runs and uploads artifacts to the GitHub Release.
+
+Tag creation options:
+
+- GitHub UI release page: create a new tag on `main`
+- Git CLI:
+
+```bash
+git checkout main
+git pull
+git tag v0.2.1
+git push origin v0.2.1
+```
+
+## 4. Rules for Contributors and Agents
+
+Use this decision rule to avoid masking real issues:
+
+- If failure is due to workflow/tooling mismatch (runner package name, deprecated action, dependency resolver mismatch), fix CI/CD config.
+- If failure is due to project code behavior/type/lint/coverage policy, fix code/tests (or explicitly change policy in a separate, reviewed decision).
+
+Do not silence rightful failures by default.
+
+Examples:
+
+- CI setup issue: runner cannot install a package due to Ubuntu image change.
+- Rightful code issue: TypeScript type mismatch in component tests.
+- Rightful quality gate: coverage below required threshold.
+
+## 5. Troubleshooting Quick Reference
+
+### `pnpm/action-setup` version mismatch
+
+Symptom:
+
+- multiple pnpm versions specified between workflow and `packageManager`
+
+Fix:
+
+- keep workflow pnpm version aligned with `package.json` `packageManager`
+
+### Linux Tauri dependency errors (`glib-sys`, `gobject-sys`)
+
+Symptom:
+
+- missing GTK/WebKit pkg-config packages
+
+Fix:
+
+- ensure Linux apt dependencies in workflow include:
+  - `pkg-config`
+  - `libgtk-3-dev`
+  - `libwebkit2gtk-4.1-dev`
+  - `libayatana-appindicator3-dev`
+  - `librsvg2-dev`
+  - `patchelf`
+
+### macOS release fails due to keychain import
+
+Symptom:
+
+- codesign/keychain import failure when no certs configured
+
+Fix:
+
+- keep release workflow unsigned by default unless signing secrets are intentionally configured
+
+### Vitest coverage crashes
+
+Symptom:
+
+- coverage plugin runtime mismatch errors
+
+Fix:
+
+- align `vitest` and `@vitest/coverage-v8` major/minor versions
+
+## 6. Contributor Checklist
+
+Before opening PR:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+pnpm run format:check
+pnpm run type-check
+pnpm run test
+```
+
+Before release tag:
+
+- all required PR checks green
+- version bump completed in all versioned files
+- release notes drafted
+

--- a/docs/development/GUIDE.md
+++ b/docs/development/GUIDE.md
@@ -24,7 +24,7 @@ rustup update
 rustup component add rustfmt clippy
 
 # Install Node.js (via Homebrew)
-brew install node@18
+brew install node@20
 npm install -g pnpm@8
 
 # Install project dependencies
@@ -66,6 +66,18 @@ pnpm run type-check
 # Full quality check (before commit)
 pnpm run lint
 ```
+
+### CI/CD Workflow
+
+Use the standardized CI/CD flow documented in:
+
+- [`docs/development/CI_CD_WORKFLOW.md`](./CI_CD_WORKFLOW.md)
+
+Highlights:
+
+- PR/push required checks run in light CI
+- heavy checks run via PR label `ci:heavy`, schedule, or manual dispatch
+- releases build on version tags (`v*`)
 
 ## Project Structure
 

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -384,29 +384,17 @@ pnpm run test:wireshark
 
 ## 4. CI/CD Pipeline
 
-GitHub Actions automatically runs all tests on:
+LumenFlow uses a split pipeline model:
 
-- Every push to `main` and `develop`
-- Every pull request
+- **Light required checks** (`.github/workflows/ci.yml`) for every PR/push to `main` and `develop`
+- **Heavy optional checks** (`.github/workflows/ci-heavy.yml`) via `ci:heavy` label, schedule, or manual run
+- **Release builds** (`.github/workflows/release.yml`) on version tags (`v*`)
 
-**Jobs (parallel execution):**
+This design keeps day-to-day CI deterministic while preserving deep validation for release confidence.
 
-1. Rust Quality (clippy, rustfmt, audit)
-2. Rust Tests (multi-platform)
-3. Advanced Rust Tests (Loom, Chaos, Property-based)
-4. Wireshark Art-Net Compliance (Linux only; validates wire format)
-5. TypeScript Quality (ESLint, type-check)
-6. TypeScript Tests (Vitest, coverage)
-7. UI Visual Regression (Playwright, cross-browser)
-8. Build (only if all tests pass)
+For exact workflow behavior and release steps, see:
 
-**Build gets blocked if:**
-
-- Any test fails
-- Code coverage drops below thresholds
-- Visual regression detected (> 0.5% pixel diff)
-- Clippy warnings present
-- Security audit finds vulnerabilities
+- [`docs/development/CI_CD_WORKFLOW.md`](./CI_CD_WORKFLOW.md)
 
 ---
 


### PR DESCRIPTION
Document the split CI model (light, heavy, release), PR label usage, release tag flow, and troubleshooting. Update testing, deployment, and development docs to reference a single source of truth.

Made-with: Cursor